### PR TITLE
fix: make ts recognize typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "module": "lib/esm/guacamole.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/guacamole.js",
-      "require": "./lib/cjs/guacamole.js"
+      "import": {
+        "types": "./guacamole.d.ts",
+        "default": "./lib/esm/guacamole.js"
+      },
+      "require": {
+        "types": "./guacamole.d.ts",
+        "default": "./lib/cjs/guacamole.js"
+      }
     }
   },
   "types": "guacamole.d.ts",


### PR DESCRIPTION
Fixes #5.

This solution fixes the issue for me, but I'm not sure if there are ramifications for older versions of Typescript or if this will work for everyone. There are more details on this solution [on StackOverflow](https://stackoverflow.com/a/77566206/675721). 