### PR TITLE
ESM named exports

### DIFF
--- a/build-esm.cjs
+++ b/build-esm.cjs
@@ -16,9 +16,12 @@ fs.rmSync('./lib/esm/', { recursive: true, force: true });
 fs.mkdirSync('./lib/esm/', { recursive: true });
 fs.writeFileSync('./lib/esm/guacamole.js', esm);
 
+//Now that we've written the ESM file, import it so we can dynamically add named exports
 import('./lib/esm/guacamole.js').then((Guac) => {
+
     const namesToExport = Object.keys(Guac.default);
-    esm += namesToExport.map(n => `const ${n} = Guacamole.${n};`).join('\n');
-    esm += `\nexport {\n${namesToExport.map(n => `    ${n},`).join('\n')}\n};`;
+    esm += namesToExport.map(n => `const ${n} = Guacamole.${n};`).join('\n');   //Generate separate variable for each key in `Guacamole`
+
+    esm += `\nexport {\n${namesToExport.map(n => `    ${n},`).join('\n')}\n};`; //Export every key
     fs.writeFileSync('./lib/esm/guacamole.js', esm);
-})
+});

--- a/build-esm.cjs
+++ b/build-esm.cjs
@@ -8,9 +8,17 @@ const src = fs.readdirSync(srcDir)
     })
     .join('\n\n');
 
-const esm = `${src}
-export default Guacamole;`;
+let esm = `${src}
+export default Guacamole;
+`;
 
 fs.rmSync('./lib/esm/', { recursive: true, force: true });
 fs.mkdirSync('./lib/esm/', { recursive: true });
 fs.writeFileSync('./lib/esm/guacamole.js', esm);
+
+import('./lib/esm/guacamole.js').then((Guac) => {
+    const namesToExport = Object.keys(Guac.default);
+    esm += namesToExport.map(n => `const ${n} = Guacamole.${n};`).join('\n');
+    esm += `\nexport {\n${namesToExport.map(n => `    ${n},`).join('\n')}\n};`;
+    fs.writeFileSync('./lib/esm/guacamole.js', esm);
+})


### PR DESCRIPTION
Adds named exports to ESM build. 

All changes are restricted to the esm build file, to avoid changing the upgrade/maintenance process. 

Doing so also happens to be the extremely lazy/easy way of doing things: we dynamically import the ESM file that was just generated by the ESM build, we enumerate all of the objects in the default export, append this to the string contents of the ESM file, and rewrite the file. 

This results in the addition of the following at the end of the file:
```
const ArrayBufferReader = Guacamole.ArrayBufferReader;
const ArrayBufferWriter = Guacamole.ArrayBufferWriter;
//...
const VideoPlayer = Guacamole.VideoPlayer;
export {
    ArrayBufferReader,
    ArrayBufferWriter,
//...
    VideoPlayer,
};
```

I have tested this and it seems to be working. If this is not merged, consider changing the README, whose example implies named exports:
>  import { Client, Tunnel } from '@glokon/guacamole-common-js';
